### PR TITLE
Fix typo in bpel.properties

### DIFF
--- a/engine/src/test/resources/bpel.properties
+++ b/engine/src/test/resources/bpel.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-## bpel Configuraiton Properties
+## bpel Configuration Properties
 
 ## Database Mode ("INTERNAL", "EXTERNAL", "EMBEDDED")
 ## What kind of database should ODE use?


### PR DESCRIPTION
Fixed tiny typo in `engine/src/test/resources/bpel.properties`.
